### PR TITLE
Compatibility Change for Django 1.8

### DIFF
--- a/dashboard_app/models.py
+++ b/dashboard_app/models.py
@@ -19,7 +19,6 @@ class DashboardWidgetLastUpdate(models.Model):
 
     last_update = models.DateTimeField(
         auto_now=True,
-        auto_now_add=True,
         verbose_name=_('Last update'),
     )
 

--- a/dashboard_app/view_mixins.py
+++ b/dashboard_app/view_mixins.py
@@ -1,6 +1,6 @@
 """Useful mixins for views."""
 from django import http
-from django.utils import simplejson as json
+import json
 from django.utils.decorators import method_decorator
 
 from .decorators import permission_required

--- a/dashboard_app/view_mixins.py
+++ b/dashboard_app/view_mixins.py
@@ -1,6 +1,7 @@
 """Useful mixins for views."""
-from django import http
 import json
+
+from django import http
 from django.utils.decorators import method_decorator
 
 from .decorators import permission_required


### PR DESCRIPTION
Simplejson has been removed in Django 1.8. Instead simple import json can be used for the same.
